### PR TITLE
add explanation of how to force G+ to see your post.

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -14,6 +14,7 @@ For Users:
    intro
    hashtags
    contribute
+   troubleshooting
 
 For Developers:
 

--- a/doc/troubleshooting.rst
+++ b/doc/troubleshooting.rst
@@ -1,0 +1,16 @@
+.. _troubleshooting:
+
+###############
+Troubleshooting
+###############
+
+I tagged my Google+ post with #spnetwork but it hasn't showed up!
+-----------------------------------------------------------------
+
+SPNetwork relies on Google+'s search function, which (ironically) behaves
+inconsistently.  You can get your post to show up as follows:
+
+  - Go to https://selectedpapers.net/ and sign in
+  - Click on your name at the top of the page
+  - Click the 'get updates' button.  If your post is more than 20 days old, 
+    adjust the dropdown box first.


### PR DESCRIPTION
Add a "troubleshooting" page to the docs.  Resolves #63.
