### PR TITLE
Topics and People link to a list of all of them.

### DIFF
--- a/spnet/_templates/get_person.html
+++ b/spnet/_templates/get_person.html
@@ -25,7 +25,7 @@ function setPriority(subcoll, topicID, field, state)
 
 <div id="header">
 <h1><img src="/favicon.ico"/><a href="/">SelectedPapers.net</a> &gt; 
-People &gt; 
+<a href="https://selectedpapers.net/people?searchString=.">People</a> &gt; 
 {% if hasattr(person, 'gplus') %}
 <a href=" {{- person.gplus['url'] -}} "> {{- person.name -}} </a>
 {% else %}

--- a/spnet/_templates/get_topic.html
+++ b/spnet/_templates/get_topic.html
@@ -13,7 +13,7 @@
 
 <div id="header">
 <h1><img src="/favicon.ico"/>
-<a href="/">SelectedPapers.net</a> &gt; Topic Group &gt; {{ topic.name }}
+<a href="/">SelectedPapers.net</a> &gt; <a href="https://selectedpapers.net/topics?searchString=."> Topic Group</a> &gt; {{ topic.name }}
 </h1>
 <form id="search" method="GET" action="/papers">
 <div class="search-for">Search or Article-id</div>


### PR DESCRIPTION
At the top of any person or topic page, there is a line that says

```
SelectedPapers.net > People > Name
```

or

```
SelectedPapers.net > Topic Group > Topic
```

This PR makes "People" and "Topic Group" link to an index of all people or all topics (by doing a search for ".").

It's not as pretty as it could be, but having easy access to an index of everybody/everything is useful.  Yes, you get a long list of results, but you can then use your browser's find function to find any user, check whether a given person is using spnet, or check whether anybody is using a tag with "numerical" somewhere in it that you're not aware of (for instance).
